### PR TITLE
improvement: hide_sale_date/in_words/payment_type

### DIFF
--- a/lib/LMSDocuments/LMSEzpdfInvoice.php
+++ b/lib/LMSDocuments/LMSEzpdfInvoice.php
@@ -143,8 +143,10 @@ class LMSEzpdfInvoice extends LMSInvoice {
 		$font_size = 12;
 		$this->backend->text_align_right($x, $y, $font_size, trans('Settlement date:').' ');
 		$y = $y - $this->backend->text_align_left($x, $y, $font_size, date("Y/m/d", $this->data['cdate']));
-		$this->backend->text_align_right($x, $y, $font_size, trans('Sale date:').' ');
-		$y = $y - $this->backend->text_align_left($x, $y, $font_size, date("Y/m/d", $this->data['sdate']));
+		if (!ConfigHelper::checkConfig('invoices.hide_sale_date')) {
+			$this->backend->text_align_right($x, $y, $font_size, trans('Sale date:').' ');
+			$y = $y - $this->backend->text_align_left($x, $y, $font_size, date("Y/m/d", $this->data['sdate']));
+		}
 		$this->backend->text_align_right($x, $y, $font_size,
 			($this->use_alert_color ? '<c:color:255,0,0>' : '')
 			. trans('Deadline:').' '
@@ -153,8 +155,10 @@ class LMSEzpdfInvoice extends LMSInvoice {
 			($this->use_alert_color ? '<c:color:255,0,0>' : '')
 			. date("Y/m/d", $this->data['pdate'])
 			. ($this->use_alert_color ? '</c:color>' : ''));
-		$this->backend->text_align_right($x, $y, $font_size, trans('Payment type:').' ');
-		$y = $y - $this->backend->text_align_left($x, $y, $font_size, $this->data['paytypename']);
+		if (!ConfigHelper::checkConfig('invoices.hide_payment_type')) {
+			$this->backend->text_align_right($x, $y, $font_size, trans('Payment type:').' ');
+			$y = $y - $this->backend->text_align_left($x, $y, $font_size, $this->data['paytypename']);
+		}
 		return $y;
 	}
 
@@ -877,7 +881,8 @@ class LMSEzpdfInvoice extends LMSInvoice {
 				($this->use_alert_color ? '<c:color:255,0,0>' : '')
 				. trans('To pay:') . ' ' . moneyf($this->data['value'])
 				. ($this->use_alert_color ? '</c:color>' : ''));
-		$y = $y - $this->backend->text_align_left($x,$y,10, trans('In words:') . ' ' . moneyf_in_words($this->data['value']));
+		if (!ConfigHelper::checkConfig('invoices.hide_in_words'))
+			$y = $y - $this->backend->text_align_left($x,$y,10, trans('In words:') . ' ' . moneyf_in_words($this->data['value']));
 		return $y;
 	}
 

--- a/lib/LMSDocuments/LMSTcpdfInvoice.php
+++ b/lib/LMSDocuments/LMSTcpdfInvoice.php
@@ -596,7 +596,8 @@ class LMSTcpdfInvoice extends LMSInvoice {
 	protected function invoice_date() {
 		$this->backend->SetFont('arial', '', 8);
 		$this->backend->writeHTMLCell(0, 0, '', 10, trans('Settlement date:') . ' <b>' . date("d.m.Y", $this->data['cdate']) . '</b>', 0, 1, 0, true, 'R');
-		$this->backend->writeHTMLCell(0, 0, '', '', trans('Sale date:') . ' <b>' . date("d.m.Y", $this->data['sdate']) . '</b>', 0, 1, 0, true, 'R');
+		if (!ConfigHelper::checkConfig('invoices.hide_sale_date'))
+			$this->backend->writeHTMLCell(0, 0, '', '', trans('Sale date:') . ' <b>' . date("d.m.Y", $this->data['sdate']) . '</b>', 0, 1, 0, true, 'R');
 	}
 
 	protected function invoice_title() {
@@ -761,7 +762,8 @@ class LMSTcpdfInvoice extends LMSInvoice {
 		}
 
 		$this->backend->SetFont('arial', '', 8);
-		$this->backend->writeHTMLCell(0, 5, '', '', trans('In words:') . ' ' . moneyf_in_words($this->data['value']), 0, 1, 0, true, 'L');
+		if (!ConfigHelper::checkConfig('invoices.hide_in_words'))
+			$this->backend->writeHTMLCell(0, 5, '', '', trans('In words:') . ' ' . moneyf_in_words($this->data['value']), 0, 1, 0, true, 'L');
 	}
 
 	protected function invoice_balance() {
@@ -780,7 +782,8 @@ class LMSTcpdfInvoice extends LMSInvoice {
 			if ($this->use_alert_color)
 					$this->backend->SetTextColorArray();
 		}
-		$this->backend->writeHTMLCell(0, 0, '', '', trans('Payment type:') . '<b>' . $this->data['paytypename'] . '</b>', 0, 1, 0, true, 'R');
+		if (!ConfigHelper::checkConfig('invoices.hide_payment_type'))
+			$this->backend->writeHTMLCell(0, 0, '', '', trans('Payment type:') . '<b>' . $this->data['paytypename'] . '</b>', 0, 1, 0, true, 'R');
 	}
 
 	protected function invoice_expositor() {

--- a/templates/default/invoice/invoice.html
+++ b/templates/default/invoice/invoice.html
@@ -26,15 +26,15 @@
 		</TD>
 		<TD WIDTH="1%" NOWRAP ALIGN="RIGHT" VALIGN="TOP" CLASS="sdr">
 			{trans("Draw-up date:")}<BR>
-			{trans("Sale date:")}<BR>
+			{if !ConfigHelper::checkConfig('invoices.hide_sale_date')}{trans("Sale date:")}<BR>{/if}
 			{trans("Deadline:")}<BR>
-			{trans("Payment type:")}
+			{if !ConfigHelper::checkConfig('invoices.hide_payment_type')}{trans("Payment type:")}{/if}
 		</TD>
 		<TD WIDTH="1%" NOWRAP ALIGN="LEFT" VALIGN="TOP" CLASS="sdr">
 			{$invoice.cdate|date_format:"%Y/%m/%d"}{if $invoice.division_cplace != ""}, {$invoice.division_cplace}{/if}<BR>
-			{$invoice.sdate|date_format:"%Y/%m/%d"}<BR>
+			{if !ConfigHelper::checkConfig('invoices.hide_sale_date')}$invoice.sdate|date_format:"%Y/%m/%d"}<BR>{/if}
 			{$invoice.pdate|date_format:"%Y/%m/%d"}<BR>
-			{$invoice.paytypename}
+			{if !ConfigHelper::checkConfig('invoices.hide_payment_type')}{$invoice.paytypename}{/if}
 		</TD>
 	</TR>
 	<TR>
@@ -363,6 +363,7 @@
 			{/if}
 		</TD>
 	</TR>
+	{if !ConfigHelper::checkConfig('invoices.hide_in_words')}
 	<TR>
 		<TD WIDTH="50%" ALIGN="RIGHT" CLASS="SDR">
 			{trans("In words:")}
@@ -373,6 +374,7 @@
 			{/if}
 		</TD>
 	</TR>
+	{/if}
 	<TR>
 		<TD WIDTH="100%" COLSPAN="2">
 			&nbsp;


### PR DESCRIPTION
Adds support fo hiding certain invoice elements.
- Sale date via invoices.hide_sale_date
- In words via invoices.hide_in_words
- Payment type via invoices.hide_payment_type